### PR TITLE
Adding .env and .venv to excludes

### DIFF
--- a/colint/pyproject.toml
+++ b/colint/pyproject.toml
@@ -9,8 +9,11 @@ exclude = [
     "docs",
     "notebooks",
     "poc_materials",
-    ".buildozer"
+    ".buildozer",
+    ".env",
+    ".venv"
 ]
+
 extend-ignore = [
     # Styling rules already handled by black
     "E1",
@@ -34,13 +37,13 @@ per-file-ignores = '''
 
 [tool.isort]
 profile = "black"
-skip_glob = ["*/venv/*", "*/env/*", "*/docs/*", "*/lint_env/*"]
+skip_glob = ["*/venv/*", "*/env/*", "*/docs/*", "*/lint_env/*", "*/.venv/*"]
 
 
 [tool.black]
 line-length = 120
 exclude = '''
-    lint_env\/|venv\/|env\/|docs\/|notebooks\/|poc\_materials\/|\.buildozer\/
+    lint_env\/|venv\/|env\/|docs\/|notebooks\/|poc\_materials\/|\.buildozer\/|.venv\/|.env\/
 '''
 preview = true
 
@@ -51,6 +54,7 @@ exclude = [
     "*/.venv/*",
     "*/lint_env/*",
     "*/env/*",
+    "*/.env/*",
     "*/docs/*",
 ]
 


### PR DESCRIPTION
Adding .env and .venv folders to excludes for flake8, vulture, black, and isort, as they are name commonly used for virtual environment folders.